### PR TITLE
Update the dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # Dependencies
 
-- `bash`, `curl`, `tar`: generic POSIX utilities.
+- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
 
 # Install
 


### PR DESCRIPTION
Only slightly pedantic, but bash/curl/tar are not POSIX utilities.

I'll send the same update to the asdf plugin template