### PR TITLE
fix: use versionsort.suffix to sort pre release versions before release

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,7 +21,7 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+	version="$(list_all_versions_sorted | tail -n1 | xargs echo)"
 else
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
 fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions_sorted | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -17,21 +17,16 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
-sort_versions() {
-	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-list_github_tags() {
-	git ls-remote --tags --refs "$GH_REPO" |
+list_github_tags_sorted() {
+	git -c 'versionsort.suffix=-beta' ls-remote --tags --refs --sort version:refname "$GH_REPO" |
 		grep -o 'refs/tags/.*' | cut -d/ -f3- |
 		sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
 }
 
-list_all_versions() {
+list_all_versions_sorted() {
 	# TODO: Adapt this. By default we simply list the tag names from GitHub releases.
 	# Change this function if tuist has other means of determining installable versions.
-	list_github_tags
+	list_github_tags_sorted
 }
 
 download_release() {


### PR DESCRIPTION
Currently `mise ls-remote tuist` sorts `-beta` versions after release version:
```
3.42.1
3.42.2
4.0.0
4.0.0-beta-1
4.0.0-beta.2
4.0.0-beta.3
4.0.0-beta.4
4.1.0
```

 We can use `git config versionsort.suffix` to fix this behavior. From man git-config:

```
>versionsort.suffix
           Even when version sort is used in git-tag(1), tagnames with the same base version but different suffixes are still sorted lexicographically,
           resulting e.g. in prerelease tags appearing after the main release (e.g. "1.0-rc1" after "1.0"). This variable can be specified to determine the
           sorting order of tags with different suffixes.

           By specifying a single suffix in this variable, any tagname containing that suffix will appear before the corresponding main release. E.g. if the
           variable is set to "-rc", then all "1.0-rcX" tags will appear before "1.0". If specified multiple times, once per suffix, then the order of
           suffixes in the configuration will determine the sorting order of tagnames with those suffixes. E.g. if "-pre" appears before "-rc" in the
           configuration, then all "1.0-preX" tags will be listed before any "1.0-rcX" tags. The placement of the main release tag relative to tags with
           various suffixes can be determined by specifying the empty suffix among those other suffixes. E.g. if the suffixes "-rc", "", "-ck" and "-bfs"
           appear in the configuration in this order, then all "v4.8-rcX" tags are listed first, followed by "v4.8", then "v4.8-ckX" and finally "v4.8-bfsX".

           If more than one suffixes match the same tagname, then that tagname will be sorted according to the suffix which starts at the earliest position in
           the tagname. If more than one different matching suffixes start at that earliest position, then that tagname will be sorted according to the
           longest of those suffixes. The sorting order between different suffixes is undefined if they are in multiple config files.

```


After changes it will look like this:

```
3.42.1
3.42.2
4.0.0-beta-1
4.0.0-beta.2
4.0.0-beta.3
4.0.0-beta.4
4.0.0
4.1.0
```

Original discussion in slack: https://tuistapp.slack.com/archives/CCXC295QS/p1707746179744519