### PR TITLE
fix: filter tags related to app releases

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -20,7 +20,8 @@ fi
 list_github_tags_sorted() {
 	git -c 'versionsort.suffix=-beta' ls-remote --tags --refs --sort version:refname "$GH_REPO" |
 		grep -o 'refs/tags/.*' | cut -d/ -f3- |
-		sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+		sed 's/^v//' | # NOTE: You might want to adapt this sed to remove non-version strings from tags
+		grep -v "@"    # Filtering out tags with @ tied to non-CLI releases
 }
 
 list_all_versions_sorted() {


### PR DESCRIPTION
The `tuist/tuist` is moving to a monorepo setup with this [PR](https://github.com/tuist/tuist/pull/6618) with two projects: the CLI and the Tuist macOS app. The latter is being added in the attached PR.

The Tuist app releases are tagged with `app@x.y.z` whereas CLI releases stay without a prefix (`x.y.z`). To properly get the list of tags in this plugin, we need to filter out the app-related tags.