### PR TITLE
fix: filter out releases with the 'app@' prefix from the latest-stable script

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,15 +21,14 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-    # Get the latest version excluding those with 'app@' prefix
-    version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	# Get the latest version excluding those with 'app@' prefix
+	version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
 else
-    version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
-    # Check if the version has 'app@' prefix and fetch an alternative version if it does
-    if [[ "$version" == app@* ]]; then
-        version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
-    fi
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+	# Check if the version has 'app@' prefix and fetch an alternative version if it does
+	if [[ "$version" == app@* ]]; then
+		version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	fi
 fi
-
 
 printf "%s\n" "$version"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,9 +21,15 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	version="$(list_all_versions_sorted | tail -n1 | xargs echo)"
+    # Get the latest version excluding those with 'app@' prefix
+    version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
 else
-	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+    version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+    # Check if the version has 'app@' prefix and fetch an alternative version if it does
+    if [[ "$version" == app@* ]]; then
+        version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+    fi
 fi
+
 
 printf "%s\n" "$version"


### PR DESCRIPTION
Resolves: https://github.com/asdf-community/asdf-tuist/issues/27

After turning https://github.com/tuist/tuist into a monorepo, we have now two release tag schemes:
- `app@x.y.z`: They represent app releases
- `x.y.z`: They represent CLI releases

We [adjusted](https://github.com/asdf-community/asdf-tuist/pull/25) the logic that's used for listing all the releases, but there's one scenario that we missed, and that causes using the version `tuist@latest` with Mise to fail trying to pull an `app@x.y.z` tag if an app release is the latest release.