### PR TITLE
fix: filter out releases with 'server@' prefix from latest-stable script

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,13 +21,13 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	# Get the latest version excluding those with 'app@' prefix
-	version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	# Get the latest version excluding those with 'app@' or 'server@' prefix
+	version="$(list_all_versions_sorted | grep -v '^app@' | grep -v '^server@' | tail -n1 | xargs echo)"
 else
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
-	# Check if the version has 'app@' prefix and fetch an alternative version if it does
-	if [[ "$version" == app@* ]]; then
-		version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	# Check if the version has 'app@' or 'server@' prefix and fetch an alternative version if it does
+	if [[ "$version" == app@* ]] || [[ "$version" == server@* ]]; then
+		version="$(list_all_versions_sorted | grep -v '^app@' | grep -v '^server@' | tail -n1 | xargs echo)"
 	fi
 fi
 


### PR DESCRIPTION
## Summary
Fixes an issue where the `latest-stable` script fails when GitHub's `/releases/latest` redirects to a `server@` prefixed release.

## Problem
The Tuist repository publishes multiple types of releases:
- CLI releases: `4.104.6`, `4.103.0`, etc.
- App releases: `app@1.2.3` (already filtered)
- **Server releases**: `server@1.29.0` (not filtered - causing the bug)

Currently, GitHub's `/releases/latest` redirects to `server@1.29.0`, and the script only filters `app@*` releases. This causes:
```
Could not download https://github.com/tuist/tuist/releases/download/server@1.29.0/tuist.zip
curl: (56) The requested URL returned error: 404
```

## Solution
This PR extends the existing filtering logic to also exclude `server@` prefixed releases, similar to how `app@` releases are already handled.

### Changes
- Added `grep -v '^server@'` to filter server releases when fetching the latest version
- Added `|| [[ "$version" == server@* ]]` to detect server releases in the redirect check
- Updated comments to reflect the new filtering

## Testing
Tested locally with `mise upgrade`:
- **Before**: Failed with 404 error trying to download `server@1.29.0`
- **After**: Successfully downloads and installs `4.104.6` (latest CLI release)

## Related
This follows the same pattern as PR #28 which added filtering for `app@` prefixed releases.